### PR TITLE
feat: configurable getDisplayMedia video constraints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+- Added optional `displayMediaVideo` prop on `RiffrecProvider` to customize `getDisplayMedia` video constraints. Defaults use a lower frame rate (`5`) and `preferCurrentTab: true` where supported (Chromium).
+- Exported `DEFAULT_DISPLAY_MEDIA_VIDEO` for callers that want to extend the defaults explicitly.
+
 ## [2.0.0] - 2026-04-24
 
 - Added richer production-safe DOM context to click events, including element names, paths, classes, accessibility metadata, nearby context, bounding boxes, style snapshots, and React component paths when available.

--- a/README.md
+++ b/README.md
@@ -43,7 +43,12 @@ export function App() {
 ## Provider Props
 
 ```ts
+type RiffrecDisplayMediaVideo = MediaTrackConstraints & {
+  preferCurrentTab?: boolean;
+};
+
 interface RiffrecConfig {
+  displayMediaVideo?: Partial<RiffrecDisplayMediaVideo>;
   forceEnable?: boolean;
   forceEnableParam?: boolean | string;
   onError?: (err: Error) => void;
@@ -52,6 +57,8 @@ interface RiffrecConfig {
 ```
 
 `RiffrecProvider` is disabled in production by default. In production builds it emits a single warning and `start()` is a no-op unless `forceEnable={true}` is passed explicitly.
+
+Screen capture merges `displayMediaVideo` with built-in defaults (`DEFAULT_DISPLAY_MEDIA_VIDEO`, including `frameRate: 5` and `preferCurrentTab: true` on Chromium). Override only what you need; the browser still shows its share picker where required.
 
 For production debugging links, the host app can also opt into URL-param activation:
 

--- a/src/RiffrecProvider.tsx
+++ b/src/RiffrecProvider.tsx
@@ -85,6 +85,7 @@ export const RiffrecContext = createContext<RiffrecContextValue | null>(null);
 
 export function RiffrecProvider({
   children,
+  displayMediaVideo,
   forceEnable,
   forceEnableParam,
   onError,
@@ -94,6 +95,7 @@ export function RiffrecProvider({
   const statusRef = useRef<RiffrecStatus>("idle");
   const activeSession = useRef<ActiveSession | null>(null);
   const configRef = useRef<RiffrecConfig>({
+    displayMediaVideo,
     forceEnable,
     forceEnableParam,
     onError,
@@ -104,8 +106,14 @@ export function RiffrecProvider({
     forceEnable || isEnabledByUrlParam(forceEnableParam) || readNodeEnv() !== "production";
 
   useEffect(() => {
-    configRef.current = { forceEnable, forceEnableParam, onError, sanitizeError };
-  }, [forceEnable, forceEnableParam, onError, sanitizeError]);
+    configRef.current = {
+      displayMediaVideo,
+      forceEnable,
+      forceEnableParam,
+      onError,
+      sanitizeError
+    };
+  }, [displayMediaVideo, forceEnable, forceEnableParam, onError, sanitizeError]);
 
   useEffect(() => {
     statusRef.current = status;
@@ -180,7 +188,7 @@ export function RiffrecProvider({
     }
 
     const sessionStart = Date.now();
-    const screen = new ScreenCapture();
+    const screen = new ScreenCapture(configRef.current.displayMediaVideo);
     const voice = new VoiceCapture();
     const eventCapture = new EventCapture();
     const networkCapture = new NetworkCapture();

--- a/src/capture/screen.test.ts
+++ b/src/capture/screen.test.ts
@@ -1,0 +1,43 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  DEFAULT_DISPLAY_MEDIA_VIDEO,
+  ScreenCapture,
+} from "./screen";
+
+describe("ScreenCapture", () => {
+  let getDisplayMedia: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    getDisplayMedia = vi.fn().mockResolvedValue({
+      getTracks: () => [{ stop: vi.fn() }],
+    });
+
+    vi.stubGlobal("navigator", {
+      mediaDevices: { getDisplayMedia },
+    });
+
+    vi.stubGlobal(
+      "MediaRecorder",
+      class {
+        state = "recording" as const;
+        ondataavailable: ((event: BlobEvent) => void) | null = null;
+        constructor(_stream: MediaStream, _opts?: { mimeType?: string }) {}
+        start(_timeslice?: number): void {}
+        stop(): void {}
+        static isTypeSupported = (): boolean => true;
+      }
+    );
+  });
+
+  it("merges defaults with displayMediaVideo overrides for getDisplayMedia", async () => {
+    const capture = new ScreenCapture({ frameRate: 12 });
+    await capture.start();
+
+    expect(getDisplayMedia).toHaveBeenCalledTimes(1);
+    expect(getDisplayMedia).toHaveBeenCalledWith({
+      video: { ...DEFAULT_DISPLAY_MEDIA_VIDEO, frameRate: 12 },
+      audio: false,
+    });
+  });
+});

--- a/src/capture/screen.ts
+++ b/src/capture/screen.ts
@@ -1,8 +1,16 @@
+import type { RiffrecDisplayMediaVideo } from "../types";
+
 const VIDEO_MIME_TYPES = [
   "video/webm;codecs=vp9",
   "video/webm;codecs=vp8",
   "video/webm"
 ];
+
+/** Default video constraints merged with optional `displayMediaVideo` overrides on `RiffrecProvider`. */
+export const DEFAULT_DISPLAY_MEDIA_VIDEO: RiffrecDisplayMediaVideo = {
+  frameRate: 5,
+  preferCurrentTab: true
+};
 
 function browserSupportsScreenCapture(): boolean {
   return (
@@ -27,6 +35,10 @@ export class ScreenCapture {
   private chunks: BlobPart[] = [];
   private mimeType = "video/webm";
 
+  constructor(
+    private readonly displayMediaVideoOverrides: Partial<RiffrecDisplayMediaVideo> = {}
+  ) {}
+
   async start(): Promise<void> {
     if (!browserSupportsScreenCapture()) {
       throw new Error("Screen capture is not supported in this browser.");
@@ -35,8 +47,12 @@ export class ScreenCapture {
     try {
       this.mimeType = chooseVideoMimeType();
       this.chunks = [];
+      const video: RiffrecDisplayMediaVideo = {
+        ...DEFAULT_DISPLAY_MEDIA_VIDEO,
+        ...this.displayMediaVideoOverrides
+      };
       this.stream = await navigator.mediaDevices.getDisplayMedia({
-        video: { frameRate: 30 },
+        video,
         audio: false
       });
       this.recorder = new MediaRecorder(this.stream, { mimeType: this.mimeType });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 export { RiffrecProvider } from "./RiffrecProvider";
 export { RiffrecRecorder, type RiffrecRecorderProps } from "./RiffrecRecorder";
 export { useRiffrec } from "./useRiffrec";
+export { DEFAULT_DISPLAY_MEDIA_VIDEO } from "./capture/screen";
 export type * from "./types";

--- a/src/types.ts
+++ b/src/types.ts
@@ -93,7 +93,19 @@ export interface SessionResult {
   filesPresent: string[];
 }
 
+/**
+ * Video constraints for `getDisplayMedia({ video })`.
+ * Chromium supports `preferCurrentTab` and other extension properties.
+ */
+export type RiffrecDisplayMediaVideo = MediaTrackConstraints & {
+  preferCurrentTab?: boolean;
+};
+
 export interface RiffrecConfig {
+  /**
+   * Override default screen-capture video constraints (e.g. `frameRate`, `preferCurrentTab`).
+   */
+  displayMediaVideo?: Partial<RiffrecDisplayMediaVideo>;
   forceEnable?: boolean;
   forceEnableParam?: boolean | string;
   onError?: (err: Error) => void;


### PR DESCRIPTION
Add displayMediaVideo on RiffrecProvider with defaults (frameRate 5,
preferCurrentTab on Chromium). Export DEFAULT_DISPLAY_MEDIA_VIDEO and
document in README. Add ScreenCapture unit test for constraint merge.

Made-with: Cursor
