### PR TITLE
Fix current-tab display media defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,9 @@
 
 ## Unreleased
 
-- Added optional `displayMediaVideo` prop on `RiffrecProvider` to customize `getDisplayMedia` video constraints. Defaults use a lower frame rate (`5`) and `preferCurrentTab: true` where supported (Chromium).
-- Exported `DEFAULT_DISPLAY_MEDIA_VIDEO` for callers that want to extend the defaults explicitly.
+- Added optional `displayMedia` and `displayMediaVideo` props on `RiffrecProvider` to customize `getDisplayMedia` options and video constraints.
+- Updated default screen capture options to request current-tab capture in Chromium (`preferCurrentTab: true`, `selfBrowserSurface: "include"`) while hiding monitor capture (`monitorTypeSurfaces: "exclude"`) and keeping a lower default frame rate (`5`).
+- Exported `DEFAULT_DISPLAY_MEDIA_OPTIONS` and `DEFAULT_DISPLAY_MEDIA_VIDEO` for callers that want to extend the defaults explicitly.
 
 ## [2.0.0] - 2026-04-24
 

--- a/README.md
+++ b/README.md
@@ -43,11 +43,18 @@ export function App() {
 ## Provider Props
 
 ```ts
-type RiffrecDisplayMediaVideo = MediaTrackConstraints & {
+type RiffrecDisplayMediaVideo = MediaTrackConstraints;
+
+type RiffrecDisplayMediaOptions = DisplayMediaStreamOptions & {
   preferCurrentTab?: boolean;
+  selfBrowserSurface?: "include" | "exclude";
+  monitorTypeSurfaces?: "include" | "exclude";
+  surfaceSwitching?: "include" | "exclude";
+  systemAudio?: "include" | "exclude";
 };
 
 interface RiffrecConfig {
+  displayMedia?: Partial<RiffrecDisplayMediaOptions>;
   displayMediaVideo?: Partial<RiffrecDisplayMediaVideo>;
   forceEnable?: boolean;
   forceEnableParam?: boolean | string;
@@ -58,7 +65,7 @@ interface RiffrecConfig {
 
 `RiffrecProvider` is disabled in production by default. In production builds it emits a single warning and `start()` is a no-op unless `forceEnable={true}` is passed explicitly.
 
-Screen capture merges `displayMediaVideo` with built-in defaults (`DEFAULT_DISPLAY_MEDIA_VIDEO`, including `frameRate: 5` and `preferCurrentTab: true` on Chromium). Override only what you need; the browser still shows its share picker where required.
+Screen capture merges `displayMedia` and `displayMediaVideo` with built-in defaults. Riffrec asks Chromium to make the current tab prominent (`preferCurrentTab: true`, `selfBrowserSurface: "include"`, `monitorTypeSurfaces: "exclude"`, `surfaceSwitching: "exclude"`, `systemAudio: "exclude"`), and records browser-tab video at `frameRate: 5` by default. Override only what you need; browsers still require a user confirmation for screen capture.
 
 For production debugging links, the host app can also opt into URL-param activation:
 

--- a/src/RiffrecProvider.tsx
+++ b/src/RiffrecProvider.tsx
@@ -85,6 +85,7 @@ export const RiffrecContext = createContext<RiffrecContextValue | null>(null);
 
 export function RiffrecProvider({
   children,
+  displayMedia,
   displayMediaVideo,
   forceEnable,
   forceEnableParam,
@@ -95,6 +96,7 @@ export function RiffrecProvider({
   const statusRef = useRef<RiffrecStatus>("idle");
   const activeSession = useRef<ActiveSession | null>(null);
   const configRef = useRef<RiffrecConfig>({
+    displayMedia,
     displayMediaVideo,
     forceEnable,
     forceEnableParam,
@@ -107,13 +109,14 @@ export function RiffrecProvider({
 
   useEffect(() => {
     configRef.current = {
+      displayMedia,
       displayMediaVideo,
       forceEnable,
       forceEnableParam,
       onError,
       sanitizeError
     };
-  }, [displayMediaVideo, forceEnable, forceEnableParam, onError, sanitizeError]);
+  }, [displayMedia, displayMediaVideo, forceEnable, forceEnableParam, onError, sanitizeError]);
 
   useEffect(() => {
     statusRef.current = status;
@@ -188,7 +191,10 @@ export function RiffrecProvider({
     }
 
     const sessionStart = Date.now();
-    const screen = new ScreenCapture(configRef.current.displayMediaVideo);
+    const screen = new ScreenCapture(
+      configRef.current.displayMedia,
+      configRef.current.displayMediaVideo
+    );
     const voice = new VoiceCapture();
     const eventCapture = new EventCapture();
     const networkCapture = new NetworkCapture();

--- a/src/capture/screen.test.ts
+++ b/src/capture/screen.test.ts
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  DEFAULT_DISPLAY_MEDIA_OPTIONS,
   DEFAULT_DISPLAY_MEDIA_VIDEO,
   ScreenCapture,
 } from "./screen";
@@ -30,14 +31,29 @@ describe("ScreenCapture", () => {
     );
   });
 
-  it("merges defaults with displayMediaVideo overrides for getDisplayMedia", async () => {
-    const capture = new ScreenCapture({ frameRate: 12 });
+  it("uses top-level display media defaults for current-tab sharing", async () => {
+    const capture = new ScreenCapture();
     await capture.start();
 
     expect(getDisplayMedia).toHaveBeenCalledTimes(1);
     expect(getDisplayMedia).toHaveBeenCalledWith({
-      video: { ...DEFAULT_DISPLAY_MEDIA_VIDEO, frameRate: 12 },
-      audio: false,
+      ...DEFAULT_DISPLAY_MEDIA_OPTIONS,
+      video: DEFAULT_DISPLAY_MEDIA_VIDEO,
+    });
+  });
+
+  it("merges displayMedia and displayMediaVideo overrides for getDisplayMedia", async () => {
+    const capture = new ScreenCapture(
+      { monitorTypeSurfaces: "include", video: { frameRate: 10 } },
+      { frameRate: 12 }
+    );
+    await capture.start();
+
+    expect(getDisplayMedia).toHaveBeenCalledTimes(1);
+    expect(getDisplayMedia).toHaveBeenCalledWith({
+      ...DEFAULT_DISPLAY_MEDIA_OPTIONS,
+      monitorTypeSurfaces: "include",
+      video: { ...DEFAULT_DISPLAY_MEDIA_VIDEO, frameRate: 10 },
     });
   });
 });

--- a/src/capture/screen.ts
+++ b/src/capture/screen.ts
@@ -1,4 +1,4 @@
-import type { RiffrecDisplayMediaVideo } from "../types";
+import type { RiffrecDisplayMediaOptions, RiffrecDisplayMediaVideo } from "../types";
 
 const VIDEO_MIME_TYPES = [
   "video/webm;codecs=vp9",
@@ -6,10 +6,19 @@ const VIDEO_MIME_TYPES = [
   "video/webm"
 ];
 
-/** Default video constraints merged with optional `displayMediaVideo` overrides on `RiffrecProvider`. */
 export const DEFAULT_DISPLAY_MEDIA_VIDEO: RiffrecDisplayMediaVideo = {
   frameRate: 5,
-  preferCurrentTab: true
+  displaySurface: "browser"
+};
+
+export const DEFAULT_DISPLAY_MEDIA_OPTIONS: RiffrecDisplayMediaOptions = {
+  audio: false,
+  video: DEFAULT_DISPLAY_MEDIA_VIDEO,
+  preferCurrentTab: true,
+  selfBrowserSurface: "include",
+  monitorTypeSurfaces: "exclude",
+  surfaceSwitching: "exclude",
+  systemAudio: "exclude"
 };
 
 function browserSupportsScreenCapture(): boolean {
@@ -36,6 +45,7 @@ export class ScreenCapture {
   private mimeType = "video/webm";
 
   constructor(
+    private readonly displayMediaOverrides: Partial<RiffrecDisplayMediaOptions> = {},
     private readonly displayMediaVideoOverrides: Partial<RiffrecDisplayMediaVideo> = {}
   ) {}
 
@@ -47,14 +57,21 @@ export class ScreenCapture {
     try {
       this.mimeType = chooseVideoMimeType();
       this.chunks = [];
+      const displayMediaVideoOverrides =
+        typeof this.displayMediaOverrides.video === "object" && this.displayMediaOverrides.video !== null
+          ? this.displayMediaOverrides.video
+          : {};
       const video: RiffrecDisplayMediaVideo = {
         ...DEFAULT_DISPLAY_MEDIA_VIDEO,
-        ...this.displayMediaVideoOverrides
+        ...this.displayMediaVideoOverrides,
+        ...displayMediaVideoOverrides
       };
-      this.stream = await navigator.mediaDevices.getDisplayMedia({
-        video,
-        audio: false
-      });
+      const options: RiffrecDisplayMediaOptions = {
+        ...DEFAULT_DISPLAY_MEDIA_OPTIONS,
+        ...this.displayMediaOverrides,
+        video
+      };
+      this.stream = await navigator.mediaDevices.getDisplayMedia(options);
       this.recorder = new MediaRecorder(this.stream, { mimeType: this.mimeType });
       this.recorder.ondataavailable = (event) => {
         if (event.data.size > 0) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 export { RiffrecProvider } from "./RiffrecProvider";
 export { RiffrecRecorder, type RiffrecRecorderProps } from "./RiffrecRecorder";
 export { useRiffrec } from "./useRiffrec";
-export { DEFAULT_DISPLAY_MEDIA_VIDEO } from "./capture/screen";
+export { DEFAULT_DISPLAY_MEDIA_OPTIONS, DEFAULT_DISPLAY_MEDIA_VIDEO } from "./capture/screen";
 export type * from "./types";

--- a/src/types.ts
+++ b/src/types.ts
@@ -93,17 +93,23 @@ export interface SessionResult {
   filesPresent: string[];
 }
 
-/**
- * Video constraints for `getDisplayMedia({ video })`.
- * Chromium supports `preferCurrentTab` and other extension properties.
- */
-export type RiffrecDisplayMediaVideo = MediaTrackConstraints & {
+export type RiffrecDisplayMediaVideo = MediaTrackConstraints;
+
+export type RiffrecDisplayMediaOptions = DisplayMediaStreamOptions & {
   preferCurrentTab?: boolean;
+  selfBrowserSurface?: "include" | "exclude";
+  monitorTypeSurfaces?: "include" | "exclude";
+  surfaceSwitching?: "include" | "exclude";
+  systemAudio?: "include" | "exclude";
 };
 
 export interface RiffrecConfig {
   /**
-   * Override default screen-capture video constraints (e.g. `frameRate`, `preferCurrentTab`).
+   * Override default screen-capture options passed to `getDisplayMedia()`.
+   */
+  displayMedia?: Partial<RiffrecDisplayMediaOptions>;
+  /**
+   * Override default screen-capture video constraints (e.g. `frameRate`).
    */
   displayMediaVideo?: Partial<RiffrecDisplayMediaVideo>;
   forceEnable?: boolean;


### PR DESCRIPTION
Move Chromium screen-sharing hints to top-level getDisplayMedia options and keep video-only defaults under video constraints.

Made-with: Cursor
