### PR TITLE
Download sessions and show stop overlay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 - Added optional `displayMedia` and `displayMediaVideo` props on `RiffrecProvider` to customize `getDisplayMedia` options and video constraints.
 - Updated default screen capture options to request current-tab capture in Chromium (`preferCurrentTab: true`, `selfBrowserSurface: "include"`) while hiding monitor capture (`monitorTypeSurfaces: "exclude"`) and keeping a lower default frame rate (`5`).
 - Exported `DEFAULT_DISPLAY_MEDIA_OPTIONS` and `DEFAULT_DISPLAY_MEDIA_VIDEO` for callers that want to extend the defaults explicitly.
+- Changed session saving to automatically download a zip instead of prompting for a folder with the File System Access API.
+- Added a provider-level recording overlay with a prominent "Stop and save" action.
 
 ## [2.0.0] - 2026-04-24
 

--- a/README.md
+++ b/README.md
@@ -91,12 +91,12 @@ Use the hook when you want to build your own recording controls:
 const { start, stop, status } = useRiffrec();
 ```
 
-`status` is one of `"idle"`, `"recording"`, `"stopping"`, `"disabled"`, or `"error"`. `stop()` returns:
+`status` is one of `"idle"`, `"recording"`, `"stopping"`, `"disabled"`, or `"error"`. While recording, `RiffrecProvider` renders a fixed stop control above the host app so the user always has a clear "Stop and save" action. `stop()` downloads a zip file and returns:
 
 ```ts
 {
   sessionPath: string | null;
-  method: "filesystem" | "zip";
+  method: "zip";
   filesPresent: string[];
 }
 ```
@@ -117,7 +117,7 @@ const { start, stop, status } = useRiffrec();
 </RiffrecProvider>
 ```
 
-Before recording starts, the component explains that Riffrec records screen video, microphone audio, clicks, navigation, network URLs/statuses, and console errors. The user must check a consent box before browser capture prompts open. While recording, it shows a visible status indicator next to the stop button.
+Before recording starts, the component explains that Riffrec records screen video, microphone audio, clicks, navigation, network URLs/statuses, and console errors. The user must check a consent box before browser capture prompts open. While recording, the provider-level stop control stays fixed above the page and saves the session zip when clicked.
 
 For custom consent copy, pass `consentTitle`, `consentDescription`, or `consentLabel`.
 
@@ -142,10 +142,9 @@ voice.webm
 | --- | --- | --- | --- |
 | Screen recording | Yes | Yes | Partial |
 | Microphone recording | Yes | Yes | Yes |
-| File System Access writes | Yes | No | No |
-| Zip fallback | Yes | Yes | Yes |
+| Automatic zip download | Yes | Yes | Yes |
 
-Chrome-family browsers can write a session directory after the user chooses a folder. Other browsers download a zip. Large `recording.webm` files over 50MB are excluded from the zip fallback; `session.json` and `events.json` are still included.
+Riffrec downloads a zip automatically through the browser download flow instead of asking the user to choose a folder. Large `recording.webm` files over 50MB are excluded from the zip; `session.json` and `events.json` are still included.
 
 ## Privacy Notes
 
@@ -155,4 +154,4 @@ Uninstrumented production sessions still include rich DOM context. Production Re
 
 ## Bundle Notes
 
-React and React DOM are peer dependencies and are externalized from the package bundle. `fflate` is the only runtime dependency and powers the zip fallback.
+React and React DOM are peer dependencies and are externalized from the package bundle. `fflate` is the only runtime dependency and powers zip downloads.

--- a/src/RiffrecProvider.tsx
+++ b/src/RiffrecProvider.tsx
@@ -5,6 +5,7 @@ import {
   useMemo,
   useRef,
   useState,
+  type CSSProperties,
   type ReactNode
 } from "react";
 import * as React from "react";
@@ -25,6 +26,77 @@ import type {
 
 const DEFAULT_FORCE_ENABLE_PARAM = "riffrec";
 const ENABLE_PARAM_VALUES = new Set(["", "1", "true", "on", "yes"]);
+
+const recordingOverlayStyle: CSSProperties = {
+  position: "fixed",
+  top: 18,
+  left: "50%",
+  transform: "translateX(-50%)",
+  zIndex: 2147483647,
+  display: "flex",
+  alignItems: "center",
+  gap: 14,
+  maxWidth: "calc(100vw - 32px)",
+  padding: "14px 16px 14px 18px",
+  borderRadius: 999,
+  background: "rgba(15, 23, 42, 0.94)",
+  color: "#ffffff",
+  boxShadow: "0 24px 70px rgba(15, 23, 42, 0.36), 0 0 0 1px rgba(255, 255, 255, 0.12)",
+  fontFamily:
+    'ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif',
+  pointerEvents: "auto"
+};
+
+const recordingDotStyle: CSSProperties = {
+  width: 14,
+  height: 14,
+  flex: "0 0 auto",
+  borderRadius: "50%",
+  background: "#ef4444",
+  boxShadow: "0 0 0 6px rgba(239, 68, 68, 0.22), 0 0 24px rgba(239, 68, 68, 0.72)"
+};
+
+const recordingTextStyle: CSSProperties = {
+  display: "flex",
+  flexDirection: "column",
+  minWidth: 0,
+  lineHeight: 1.15
+};
+
+const recordingTitleStyle: CSSProperties = {
+  fontSize: 15,
+  fontWeight: 800,
+  letterSpacing: "0.02em",
+  textTransform: "uppercase"
+};
+
+const recordingHintStyle: CSSProperties = {
+  marginTop: 3,
+  color: "rgba(255, 255, 255, 0.78)",
+  fontSize: 13,
+  fontWeight: 500,
+  whiteSpace: "nowrap"
+};
+
+const recordingStopButtonStyle: CSSProperties = {
+  border: "1px solid rgba(255, 255, 255, 0.28)",
+  borderRadius: 999,
+  padding: "13px 20px",
+  background: "#ef4444",
+  color: "#ffffff",
+  boxShadow: "0 10px 30px rgba(239, 68, 68, 0.38)",
+  font: "inherit",
+  fontSize: 16,
+  fontWeight: 900,
+  cursor: "pointer",
+  whiteSpace: "nowrap"
+};
+
+const recordingStopDisabledStyle: CSSProperties = {
+  ...recordingStopButtonStyle,
+  cursor: "not-allowed",
+  opacity: 0.68
+};
 
 interface RiffrecProviderProps extends RiffrecConfig {
   children?: ReactNode;
@@ -265,5 +337,30 @@ export function RiffrecProvider({
     [isEnabled, start, status, stop]
   );
 
-  return <RiffrecContext.Provider value={value}>{children}</RiffrecContext.Provider>;
+  const isRecordingVisible = status === "recording" || status === "stopping";
+
+  return (
+    <RiffrecContext.Provider value={value}>
+      {children}
+      {isRecordingVisible ? (
+        <div aria-live="polite" role="status" style={recordingOverlayStyle}>
+          <span aria-hidden="true" style={recordingDotStyle} />
+          <span style={recordingTextStyle}>
+            <span style={recordingTitleStyle}>Recording feedback</span>
+            <span style={recordingHintStyle}>
+              Stop when you are ready to save the ZIP file.
+            </span>
+          </span>
+          <button
+            type="button"
+            disabled={status === "stopping"}
+            style={status === "stopping" ? recordingStopDisabledStyle : recordingStopButtonStyle}
+            onClick={() => void stop()}
+          >
+            {status === "stopping" ? "Saving..." : "Stop and save"}
+          </button>
+        </div>
+      ) : null}
+    </RiffrecContext.Provider>
+  );
 }

--- a/src/output/session.test.ts
+++ b/src/output/session.test.ts
@@ -1,10 +1,43 @@
-import { describe, expect, it } from "vitest";
-import { createSessionDirName } from "./session";
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { CaptureOutputs } from "../types";
+import { createSessionDirName, SessionWriter } from "./session";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 describe("createSessionDirName", () => {
   it("uses the documented riffrec date-time prefix", () => {
     const name = createSessionDirName(new Date("2026-04-22T08:45:00"));
 
     expect(name).toMatch(/^riffrec-2026-04-22-0845-[a-zA-Z0-9-]{6}$/);
+  });
+
+  it("downloads a zip without prompting for a folder", async () => {
+    const showDirectoryPicker = vi.fn();
+    Object.defineProperty(window, "showDirectoryPicker", {
+      configurable: true,
+      value: showDirectoryPicker
+    });
+    vi.spyOn(URL, "createObjectURL").mockReturnValue("blob:riffrec");
+    vi.spyOn(URL, "revokeObjectURL").mockImplementation(() => {});
+    vi.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(() => {});
+
+    const outputs: CaptureOutputs = {
+      sessionId: "session-1",
+      startedAt: new Date("2026-04-22T08:45:00"),
+      durationSeconds: 4,
+      events: [],
+      screenBlob: new Blob(["screen"], { type: "video/webm" }),
+      voiceBlob: null
+    };
+
+    const result = await new SessionWriter({ reactVersion: "19.0.0" }).stop(outputs);
+
+    expect(showDirectoryPicker).not.toHaveBeenCalled();
+    expect(result.method).toBe("zip");
+    expect(result.sessionPath).toMatch(/^riffrec-\d{4}-\d{2}-\d{2}-\d{4}-.+\.zip$/);
+    expect(result.filesPresent).toEqual(["session.json", "events.json", "recording.webm"]);
   });
 });

--- a/src/output/session.ts
+++ b/src/output/session.ts
@@ -1,6 +1,5 @@
 import type { CaptureOutputs, EventsJson, SessionJson, SessionResult } from "../types";
 import { RIFFREC_SCHEMA_VERSION } from "../types";
-import { FileSystemWriter, isSupported as isFileSystemSupported } from "./filesystem";
 import { filterZipSessionFiles, ZipWriter } from "./zip";
 
 interface SessionWriterOptions {
@@ -84,7 +83,6 @@ function withSessionJson(
 }
 
 export class SessionWriter {
-  private readonly fileSystemWriter = new FileSystemWriter();
   private readonly zipWriter = new ZipWriter();
 
   constructor(private readonly options: SessionWriterOptions = {}) {}
@@ -101,24 +99,6 @@ export class SessionWriter {
     }
     if (outputs.voiceBlob) {
       files.set("voice.webm", outputs.voiceBlob);
-    }
-
-    try {
-      if (isFileSystemSupported()) {
-        const filesystemSession = withSessionJson(
-          files,
-          outputs,
-          endedAt,
-          this.options.reactVersion ?? null
-        );
-        const sessionPath = await this.fileSystemWriter.writeSession(
-          sessionDirName,
-          filesystemSession.files
-        );
-        return { sessionPath, method: "filesystem", filesPresent: filesystemSession.filesPresent };
-      }
-    } catch {
-      // Fall back to zip below. Capture failures must not crash the host app.
     }
 
     const zipSession = withSessionJson(

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,7 +4,7 @@ export type RiffrecSchemaVersion = typeof RIFFREC_SCHEMA_VERSION;
 
 export type RiffrecStatus = "idle" | "recording" | "stopping" | "disabled" | "error";
 
-export type RiffrecWriteMethod = "filesystem" | "zip";
+export type RiffrecWriteMethod = "zip";
 
 export interface ElementBoundingBox {
   x: number;


### PR DESCRIPTION
Save recordings through the browser ZIP download flow and render a prominent provider-level stop/save control while recording.

Made-with: Cursor
