### PR TITLE
Make download notice configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - Exported `DEFAULT_DISPLAY_MEDIA_OPTIONS` and `DEFAULT_DISPLAY_MEDIA_VIDEO` for callers that want to extend the defaults explicitly.
 - Changed session saving to automatically download a zip instead of prompting for a folder with the File System Access API.
 - Added a provider-level recording overlay with a prominent "Stop and save" action.
-- Added a post-download notice that tells users to share the downloaded zip for feedback.
+- Added a customizable post-download notice that tells users to share the downloaded zip for feedback.
 
 ## [2.0.0] - 2026-04-24
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ type RiffrecDisplayMediaOptions = DisplayMediaStreamOptions & {
 interface RiffrecConfig {
   displayMedia?: Partial<RiffrecDisplayMediaOptions>;
   displayMediaVideo?: Partial<RiffrecDisplayMediaVideo>;
+  downloadNoticeTitle?: string;
+  downloadNoticeMessage?: string;
   forceEnable?: boolean;
   forceEnableParam?: boolean | string;
   onError?: (err: Error) => void;
@@ -91,7 +93,7 @@ Use the hook when you want to build your own recording controls:
 const { start, stop, status } = useRiffrec();
 ```
 
-`status` is one of `"idle"`, `"recording"`, `"stopping"`, `"disabled"`, or `"error"`. While recording, `RiffrecProvider` renders a fixed stop control above the host app so the user always has a clear "Stop and save" action. After the download starts, it shows a confirmation telling the user to share the zip for feedback. `stop()` downloads a zip file and returns:
+`status` is one of `"idle"`, `"recording"`, `"stopping"`, `"disabled"`, or `"error"`. While recording, `RiffrecProvider` renders a fixed stop control above the host app so the user always has a clear "Stop and save" action. After the download starts, it shows a confirmation telling the user to share the zip for feedback. Host apps can customize that confirmation with `downloadNoticeTitle` and `downloadNoticeMessage`. `stop()` downloads a zip file and returns:
 
 ```ts
 {

--- a/src/RiffrecProvider.tsx
+++ b/src/RiffrecProvider.tsx
@@ -192,6 +192,8 @@ export function RiffrecProvider({
   children,
   displayMedia,
   displayMediaVideo,
+  downloadNoticeTitle = "We downloaded the zip file.",
+  downloadNoticeMessage = "Share the zip file for feedback.",
   forceEnable,
   forceEnableParam,
   onError,
@@ -403,8 +405,8 @@ export function RiffrecProvider({
             ✓
           </span>
           <span style={recordingTextStyle}>
-            <span style={recordingTitleStyle}>We downloaded the zip file.</span>
-            <span style={recordingHintStyle}>Share to Kieran for feedback.</span>
+            <span style={recordingTitleStyle}>{downloadNoticeTitle}</span>
+            <span style={recordingHintStyle}>{downloadNoticeMessage}</span>
           </span>
           <button
             type="button"

--- a/src/types.ts
+++ b/src/types.ts
@@ -112,6 +112,8 @@ export interface RiffrecConfig {
    * Override default screen-capture video constraints (e.g. `frameRate`).
    */
   displayMediaVideo?: Partial<RiffrecDisplayMediaVideo>;
+  downloadNoticeTitle?: string;
+  downloadNoticeMessage?: string;
   forceEnable?: boolean;
   forceEnableParam?: boolean | string;
   onError?: (err: Error) => void;


### PR DESCRIPTION
Keep riffrec notice copy generic and let host apps customize the post-download instruction.

Made-with: Cursor
