### PR TITLE
fix(desktop): preserve framework links in preview dmg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Added Riffrec Desktop, a standalone macOS feedback browser for recording any website without installing the React integration.
 - Exported desktop recordings as compatible session zips containing existing event artifacts plus desktop capture context and optional notes.
 - Added a GitHub-hosted macOS preview DMG build and a direct desktop download link.
+- Fixed macOS preview DMG packaging so installed Electron framework links remain valid, and added optional local code signing for preview builds.
 - Added optional `displayMedia` and `displayMediaVideo` props on `RiffrecProvider` to customize `getDisplayMedia` options and video constraints.
 - Updated default screen capture options to request current-tab capture in Chromium (`preferCurrentTab: true`, `selfBrowserSurface: "include"`) while hiding monitor capture (`monitorTypeSurfaces: "exclude"`) and keeping a lower default frame rate (`5`).
 - Exported `DEFAULT_DISPLAY_MEDIA_OPTIONS` and `DEFAULT_DISPLAY_MEDIA_VIDEO` for callers that want to extend the defaults explicitly.

--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ Riffrec is designed to pair well with the [Compound Engineering plugin](https://
 
 Riffrec Desktop is a standalone macOS feedback browser. A feedback giver opens a website inside the app, records a reproduction, and exports a zip without the website owner installing the React package.
 
-**Download for macOS (Apple Silicon):** [Riffrec Desktop Preview `.dmg`](https://github.com/kieranklaassen/riffrec/releases/download/desktop-v0.1.0-preview.2/Riffrec-darwin-arm64.dmg)
+**Download for macOS (Apple Silicon):** [Riffrec Desktop Preview `.dmg`](https://github.com/kieranklaassen/riffrec/releases/download/desktop-v0.1.0-preview.3/Riffrec-darwin-arm64.dmg)
 
-This preview download is unsigned and unnotarized. On first launch, right-click **Riffrec.app** and choose **Open**; production distribution will use a signed and notarized build.
+This preview download is development-signed and unnotarized. On first launch, right-click **Riffrec.app** and choose **Open**; production distribution will use a Developer ID signed and notarized build.
 
 ```sh
 cd desktop
@@ -36,7 +36,13 @@ open out/Riffrec-darwin-$(test "$(uname -m)" = arm64 && echo arm64 || echo x64).
 
 The first release is macOS-first and packages for the current Mac architecture. The app requires macOS Screen Recording permission to record its browser window, and Microphone permission only when narration is enabled.
 
-`npm run package` produces local `.dmg` and `.zip` development builds. Before broadly distributing a download to feedback participants, sign and notarize the app with Apple Developer credentials so macOS can verify and launch it normally.
+`npm run package` produces local `.dmg` and `.zip` development builds. To sign the app and disk image with a certificate installed through Xcode or Keychain Access, set `RIFFREC_CODESIGN_IDENTITY`:
+
+```sh
+RIFFREC_CODESIGN_IDENTITY="Apple Development: Your Name (TEAMID)" npm run package
+```
+
+An Apple Development signature is suitable for local testing. Before broadly distributing a download to feedback participants, package with a `Developer ID Application` certificate and notarize the app so macOS can verify and launch it normally.
 
 ### Desktop Workflow
 

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -12,6 +12,7 @@
       },
       "devDependencies": {
         "@electron/fuses": "^2.1.1",
+        "@electron/osx-sign": "^2.4.0",
         "@electron/packager": "^20.0.0",
         "@types/jsdom": "^28.0.3",
         "@types/node": "^24.10.0",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -17,6 +17,7 @@
   },
   "devDependencies": {
     "@electron/fuses": "^2.1.1",
+    "@electron/osx-sign": "^2.4.0",
     "@electron/packager": "^20.0.0",
     "@types/jsdom": "^28.0.3",
     "@types/node": "^24.10.0",

--- a/desktop/scripts/package-mac.mjs
+++ b/desktop/scripts/package-mac.mjs
@@ -1,13 +1,48 @@
 import { execFileSync } from "node:child_process";
-import { cp, mkdtemp, rm, symlink } from "node:fs/promises";
+import { access, mkdtemp, readdir, readlink, rm, symlink } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { sign } from "@electron/osx-sign";
 import { packager } from "@electron/packager";
 import { flipFuses, FuseVersion, FuseV1Options } from "@electron/fuses";
 
 const root = path.dirname(path.dirname(fileURLToPath(import.meta.url)));
 const output = path.join(root, "out");
 const arch = process.arch === "arm64" ? "arm64" : "x64";
+const signingIdentity = process.env.RIFFREC_CODESIGN_IDENTITY?.trim();
+
+async function assertPortableAppBundle(appBundlePath) {
+  const requiredFrameworkExecutable = path.join(
+    appBundlePath,
+    "Contents",
+    "Frameworks",
+    "Electron Framework.framework",
+    "Electron Framework"
+  );
+  await access(requiredFrameworkExecutable);
+
+  const absoluteSymlinks = [];
+  async function visit(directory) {
+    for (const entry of await readdir(directory, { withFileTypes: true })) {
+      const entryPath = path.join(directory, entry.name);
+      if (entry.isSymbolicLink()) {
+        const target = await readlink(entryPath);
+        if (path.isAbsolute(target)) {
+          absoluteSymlinks.push(`${path.relative(appBundlePath, entryPath)} -> ${target}`);
+        }
+      } else if (entry.isDirectory()) {
+        await visit(entryPath);
+      }
+    }
+  }
+
+  await visit(appBundlePath);
+  if (absoluteSymlinks.length > 0) {
+    throw new Error(
+      `Application bundle contains non-portable absolute symlinks:\n${absoluteSymlinks.join("\n")}`
+    );
+  }
+}
 
 await rm(output, { recursive: true, force: true });
 
@@ -56,6 +91,21 @@ await flipFuses(
     [FuseV1Options.OnlyLoadAppFromAsar]: true
   }
 );
+if (signingIdentity) {
+  await sign({
+    app: appBundlePath,
+    platform: "darwin",
+    identity: signingIdentity,
+    preEmbedProvisioningProfile: false
+  });
+  console.log(`Signed application with: ${signingIdentity}`);
+} else {
+  console.warn(
+    "Application remains ad hoc signed. Set RIFFREC_CODESIGN_IDENTITY to sign with a Keychain identity."
+  );
+}
+await assertPortableAppBundle(appBundlePath);
+
 const archivePath = path.join(output, `Riffrec-${process.platform}-${arch}.zip`);
 execFileSync("/usr/bin/ditto", [
   "-c",
@@ -68,7 +118,9 @@ execFileSync("/usr/bin/ditto", [
 const diskImagePath = path.join(output, `Riffrec-${process.platform}-${arch}.dmg`);
 const diskImageContents = await mkdtemp(path.join(output, "dmg-"));
 try {
-  await cp(appBundlePath, path.join(diskImageContents, "Riffrec.app"), { recursive: true });
+  const stagedAppBundlePath = path.join(diskImageContents, "Riffrec.app");
+  execFileSync("/usr/bin/ditto", [appBundlePath, stagedAppBundlePath]);
+  await assertPortableAppBundle(stagedAppBundlePath);
   await symlink("/Applications", path.join(diskImageContents, "Applications"));
   execFileSync(
     "/usr/bin/hdiutil",
@@ -87,6 +139,14 @@ try {
   );
 } finally {
   await rm(diskImageContents, { recursive: true, force: true });
+}
+if (signingIdentity) {
+  execFileSync(
+    "/usr/bin/codesign",
+    ["--sign", signingIdentity, "--timestamp", "--force", diskImagePath],
+    { stdio: "inherit" }
+  );
+  console.log(`Signed disk image with: ${signingIdentity}`);
 }
 
 console.log(`Packaged application: ${appBundlePath}`);


### PR DESCRIPTION
## Summary

Riffrec Desktop preview installs now launch correctly from the DMG. Preview 2 staged the Electron app through Node copying that expanded framework symlinks to absolute CI-runner paths, leaving installed copies unable to load `Electron Framework` at startup.

The macOS packaging path now preserves bundle symlinks during DMG staging and fails before publication if a framework binary is missing or any absolute symlink slips into the application bundle. It also supports signing the post-fuse application and DMG from an installed Keychain identity, allowing the repaired preview build to be development-signed before upload.

## Verification

- `cd desktop && npm run typecheck && npm test` (32 tests passed)
- `RIFFREC_CODESIGN_IDENTITY="Apple Development: Kieran Klaassen (AW36Y9QCAK)" npm run package`
- Mounted the generated DMG and verified `Electron Framework -> Versions/Current/Electron Framework` resolves.
- Verified the DMG and nested application with `codesign --verify --strict` / `codesign --verify --deep --strict`.
- Installed the rebuilt application into `/Applications` and confirmed it launches past the previous dyld crash.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
