### PR TITLE
[codex] fix(desktop): keep feedback rail visible after loading a site

### DIFF
--- a/desktop/assets/styles.css
+++ b/desktop/assets/styles.css
@@ -311,6 +311,7 @@ textarea:focus-visible {
 }
 
 .feedback-rail {
+  grid-column: 2;
   min-height: 0;
   padding: 22px 20px 18px;
   background: var(--paper);


### PR DESCRIPTION
## Summary

- Pin the desktop feedback rail to the second grid column.
- Keeps the recorder controls visible after a website loads and the empty-state panel is hidden.

## Root cause

The desktop workspace is a two-column CSS grid. After a site loads, the renderer hides `#empty-state`, leaving `.feedback-rail` as the only grid item. Without an explicit grid column, auto-placement moves the rail into column 1, where it sits underneath the Electron `WebContentsView`; column 2 appears blank.

## Validation

- `npm run typecheck` from `desktop/`
- `npm test` from `desktop/`
- `npm run build` from `desktop/`

## Manual repro

1. Open Riffrec Desktop.
2. Load any website in the address bar.
3. Observe that the right feedback sidebar is blank in the preview build.
4. With this change, the feedback rail stays in the right column.
