### PR TITLE
fix(desktop): keep recorder rail visible when a website is open

### DIFF
--- a/desktop/assets/styles.css
+++ b/desktop/assets/styles.css
@@ -311,6 +311,11 @@ textarea:focus-visible {
 }
 
 .feedback-rail {
+  /* Stay in the reserved 354px right column. When .empty-state becomes
+     display:none (a site is open), grid auto-placement would otherwise move
+     this rail into column 1 — directly under the website WebContentsView,
+     which paints above HTML and hides the recorder controls. */
+  grid-column: 2;
   min-height: 0;
   padding: 22px 20px 18px;
   background: var(--paper);


### PR DESCRIPTION
## Problem

In the desktop feedback browser, the recorder rail (microphone toggle, notes, consent, **Start recording**) disappears the instant you open a website — i.e. exactly when you would start recording. The reserved right-hand strip shows only the window background.

## Root cause

`.workspace` is a two-column grid:

```css
.workspace { grid-template-columns: 1fr var(--rail-width); } /* 1fr | 354px */
```

`.empty-state` occupies column 1 and `.feedback-rail` column 2 via auto-placement. When a site loads, `renderer.ts` sets `emptyState.hidden = true`, and `[hidden] { display: none !important }` removes it from the grid. Auto-placement then flows `.feedback-rail` into **column 1** — the same region the guest `WebContentsView` is positioned over (`x: 0, width: innerWidth − railWidth`). Because a `WebContentsView` paints above HTML regardless of z-index, the rail is hidden behind the website, and the reserved 354px column 2 renders empty.

## Fix

Pin the rail to its reserved column:

```css
.feedback-rail { grid-column: 2; }
```

One line, CSS-only. No behavior change when the empty state is visible (no site open).

## Verification

Reproduced on the v0.1.0 Preview 3 desktop build: open the app → enter any site → **Open** → the entire recorder rail vanishes. Confirmed the fix live by setting `gridColumn = '2'` on `.feedback-rail` via DevTools, which immediately restored the rail in the right column with all controls functional.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
