### PR TITLE
[codex] make React primary and Desktop experimental

### DIFF
--- a/.github/workflows/desktop-preview-release.yml
+++ b/.github/workflows/desktop-preview-release.yml
@@ -1,4 +1,4 @@
-name: Desktop Preview Release
+name: Experimental Desktop Preview Release
 
 on:
   workflow_dispatch:
@@ -49,6 +49,6 @@ jobs:
             gh release create "$RELEASE_TAG" desktop/out/Riffrec-darwin-arm64.dmg \
               --target "$GITHUB_SHA" \
               --prerelease \
-              --title "Riffrec Desktop v0.1.0 Preview 2" \
-              --notes "Apple Silicon macOS preview build. This DMG is unsigned and unnotarized; right-click Riffrec.app and choose Open on first launch."
+              --title "Riffrec Desktop v0.1.0 Experimental Preview" \
+              --notes "Highly experimental Apple Silicon macOS preview. This app may break or change without notice and the React package remains the recommended way to use Riffrec. This DMG is unsigned and unnotarized; right-click Riffrec.app and choose Open on first launch."
           fi

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ coverage/
 desktop/node_modules/
 desktop/dist/
 desktop/out/
+.worktrees/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,10 @@
 
 ## Unreleased
 
-- Added Riffrec Desktop, a standalone macOS feedback browser for recording any website without installing the React integration.
+- Made the React package the recommended integration path and labeled Riffrec Desktop as a highly experimental preview in the documentation and app.
+- Added Riffrec Desktop, a highly experimental standalone macOS feedback browser for recording any website without installing the React integration.
 - Exported desktop recordings as compatible session zips containing existing event artifacts plus desktop capture context and optional notes.
-- Added a GitHub-hosted macOS preview DMG build and a direct desktop download link.
+- Added a GitHub-hosted experimental macOS preview DMG build and a direct desktop download link.
 - Fixed macOS preview DMG packaging so installed Electron framework links remain valid, and added optional local code signing for preview builds.
 - Added optional `displayMedia` and `displayMediaVideo` props on `RiffrecProvider` to customize `getDisplayMedia` options and video constraints.
 - Updated default screen capture options to request current-tab capture in Chromium (`preferCurrentTab: true`, `selfBrowserSurface: "include"`) while hiding monitor capture (`monitorTypeSurfaces: "exclude"`) and keeping a lower default frame rate (`5`).

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # riffrec
 
-`riffrec` captures golden feedback: high-signal product sessions with screen video, microphone narration, clicks, navigation, network outcomes, and console errors. Use it as a React package or as a standalone macOS feedback browser.
+`riffrec` is a React-first package for capturing golden feedback: high-signal product sessions with screen video, microphone narration, clicks, navigation, network outcomes, and console errors. Installing the React package in your app is the recommended way to use Riffrec today.
 
 There are already great tools for analytics and passive session replay. Riffrec is for the moments you intentionally turn on recording and capture the gold: the bug reproduction, the confused reaction, the broken flow, the product insight. In the age of AI slop, Riffrec gives agents concrete evidence instead of vague prompts.
 
@@ -19,44 +19,7 @@ Use it when you want to turn product usage into:
 
 Riffrec is designed to pair well with the [Compound Engineering plugin](https://github.com/EveryInc/compound-engineering-plugin). Record a session with Riffrec, then hand the session files to Compound Engineering so the agent can turn concrete product evidence into a sharper plan or implementation.
 
-## Riffrec Desktop For Any Website
-
-Riffrec Desktop is a standalone macOS feedback browser. A feedback giver opens a website inside the app, records a reproduction, and exports a zip without the website owner installing the React package.
-
-**Download for macOS (Apple Silicon):** [Riffrec Desktop Preview `.dmg`](https://github.com/kieranklaassen/riffrec/releases/download/desktop-v0.1.0-preview.3/Riffrec-darwin-arm64.dmg)
-
-This preview download is development-signed and unnotarized. On first launch, right-click **Riffrec.app** and choose **Open**; production distribution will use a Developer ID signed and notarized build.
-
-```sh
-cd desktop
-npm install
-npm run package
-open out/Riffrec-darwin-$(test "$(uname -m)" = arm64 && echo arm64 || echo x64).dmg
-```
-
-The first release is macOS-first and packages for the current Mac architecture. The app requires macOS Screen Recording permission to record its browser window, and Microphone permission only when narration is enabled.
-
-`npm run package` produces local `.dmg` and `.zip` development builds. To sign the app and disk image with a certificate installed through Xcode or Keychain Access, set `RIFFREC_CODESIGN_IDENTITY`:
-
-```sh
-RIFFREC_CODESIGN_IDENTITY="Apple Development: Your Name (TEAMID)" npm run package
-```
-
-An Apple Development signature is suitable for local testing. Before broadly distributing a download to feedback participants, package with a `Developer ID Application` certificate and notarize the app so macOS can verify and launch it normally.
-
-### Desktop Workflow
-
-1. Enter an `https://` website URL in the address bar. Local `http://localhost` URLs are supported for development feedback.
-2. Sign in or navigate inside Riffrec's isolated browser profile if required.
-3. Choose microphone and click capture, add optional reviewer notes, acknowledge the recording disclosure, and press **Start recording**.
-4. Reproduce the issue, add moment markers where useful, then press **Stop and save session**.
-5. Share the saved zip with an agent or teammate.
-
-Desktop sessions capture the webpage loaded **inside Riffrec**: screen video, optional microphone audio, DOM click element details, top-level navigation, network URLs/methods/statuses/durations, console errors, notes, and capture context. They do not capture activity in an existing Safari/Chrome/Arc tab, request or response bodies, typed values, or reliable internal React component names on third-party sites.
-
-Riffrec stores website cookies and local storage only in its dedicated local browser profile so authenticated reproductions work. It stages in-progress and unsaved recording media locally for crash recovery; interrupted or damaged drafts remain on this Mac until saved or deleted with the recovery-data action in the app. Use **Clear website sign-in data** after recording on sensitive sites.
-
-## React Package Integration
+## Recommended: React Package Integration
 
 For a developer who can integrate Riffrec in a React app, the package can additionally identify React component context during feedback.
 
@@ -164,24 +127,22 @@ For custom consent copy, pass `consentTitle`, `consentDescription`, or `consentL
 
 ## Session Format
 
-Sessions are named `riffrec-{YYYY-MM-DD}-{HHMM}-{shortid}`. A Riffrec Desktop zip contains:
+Sessions are named `riffrec-{YYYY-MM-DD}-{HHMM}-{shortid}`. A React package zip contains:
 
 ```text
 session.json
 events.json
-context.json
 recording.webm
 voice.webm         # when microphone narration was captured
-notes.md           # when notes were provided
 ```
 
-The React package includes `recording.webm` and `voice.webm` when those captures are available; it does not include desktop-only `context.json` or `notes.md`.
+The experimental desktop preview uses the same core session format and may additionally include `context.json` and `notes.md`.
 
-`session.json` records URL, React version, browser, start/end timestamps, duration, and `files_present`. Consumers should use `files_present`, and for desktop sessions `context.json.capture_outcomes`, rather than assuming optional media or text files exist.
+`session.json` records URL, React version, browser, start/end timestamps, duration, and `files_present`. Consumers should use `files_present`, and for experimental desktop sessions `context.json.capture_outcomes`, rather than assuming optional media or text files exist.
 
 `events.json` has `schema_version: "1.0.0"` and event records for clicks, network requests, console errors, and navigation. Click events include production-safe DOM context such as readable element names, selectors, class names, accessibility labels, nearby text, sibling context, bounding boxes, and a small computed-style snapshot. Credential-like query parameters such as `token`, `api_key`, and `client_secret` are redacted. Request and response bodies are not captured.
 
-Desktop-generated zips keep the same `events.json` schema. `context.json` records desktop capture options and outcomes, app/browser versions, initial/final page information, captured viewport dimensions, marker timestamps, and unavailable signal disclosures.
+Experimental desktop zips keep the same `events.json` schema. `context.json` records desktop capture options and outcomes, app/browser versions, initial/final page information, captured viewport dimensions, marker timestamps, and unavailable signal disclosures.
 
 ## Browser Support
 
@@ -193,13 +154,51 @@ Desktop-generated zips keep the same `events.json` schema. `context.json` record
 
 Riffrec downloads a zip automatically through the browser download flow instead of asking the user to choose a folder. Large `recording.webm` files over 50MB are excluded from the zip; `session.json` and `events.json` are still included.
 
+## Highly Experimental Desktop Preview
+
+> [!CAUTION]
+> Riffrec Desktop is a rough, highly experimental preview. It may break, change without notice, or disappear. It is not the recommended way to use Riffrec; use the React package above for the primary integration path.
+
+The desktop preview is a standalone macOS feedback browser for trying Riffrec on a website that has not installed the React package. It trades the React integration's deeper in-app context for a contained experimental browser that can export a compatible session zip.
+
+**Experimental download for macOS (Apple Silicon):** [Riffrec Desktop Preview `.dmg`](https://github.com/kieranklaassen/riffrec/releases/download/desktop-v0.1.0-preview.3/Riffrec-darwin-arm64.dmg)
+
+The preview is development-signed and unnotarized. On first launch, right-click **Riffrec.app** and choose **Open**. Do not rely on it for production or durable workflows.
+
+```sh
+cd desktop
+npm install
+npm run package
+open out/Riffrec-darwin-$(test "$(uname -m)" = arm64 && echo arm64 || echo x64).dmg
+```
+
+The app packages for the current Mac architecture. It requires macOS Screen Recording permission to record its browser window, and Microphone permission only when narration is enabled.
+
+`npm run package` produces local `.dmg` and `.zip` development builds. To sign the app and disk image with a certificate installed through Xcode or Keychain Access, set `RIFFREC_CODESIGN_IDENTITY`:
+
+```sh
+RIFFREC_CODESIGN_IDENTITY="Apple Development: Your Name (TEAMID)" npm run package
+```
+
+### Experimental Desktop Workflow
+
+1. Enter an `https://` website URL in the address bar. Local `http://localhost` URLs are supported for development feedback.
+2. Sign in or navigate inside Riffrec's isolated browser profile if required.
+3. Choose microphone and click capture, add optional reviewer notes, acknowledge the recording disclosure, and press **Start recording**.
+4. Reproduce the issue, add moment markers where useful, then press **Stop and save session**.
+5. Share the saved zip with an agent or teammate.
+
+Desktop sessions capture the webpage loaded **inside Riffrec**: screen video, optional microphone audio, DOM click element details, top-level navigation, network URLs/methods/statuses/durations, console errors, notes, and capture context. They do not capture activity in an existing Safari/Chrome/Arc tab, request or response bodies, typed values, or reliable internal React component names on third-party sites.
+
+Riffrec stores website cookies and local storage only in its dedicated local browser profile so authenticated reproductions work. It stages in-progress and unsaved recording media locally for crash recovery; interrupted or damaged drafts remain on this Mac until saved or deleted with the recovery-data action in the app. Use **Clear website sign-in data** after recording on sensitive sites.
+
 ## Privacy Notes
 
-Riffrec is development tooling. It can record anything visible on screen and anything spoken into the microphone. Riffrec Desktop excludes text inside form fields and editable controls from DOM click evidence. The React integration excludes password and hidden input values. Screen video and microphone audio can still contain sensitive content.
+Riffrec is development tooling. It can record anything visible on screen and anything spoken into the microphone. The React integration excludes password and hidden input values. The experimental desktop preview excludes text inside form fields and editable controls from DOM click evidence. Screen video and microphone audio can still contain sensitive content.
 
 Uninstrumented production sessions still include rich DOM context. Production React component names are only reliable when elements include `data-component`. React Fiber names are useful in development but often minified in production. A future `riffrec-babel-plugin` package can automate production component attributes.
 
-Riffrec Desktop loads remote pages in an Electron browser surface with Node integration disabled, context isolation and sandboxing enabled, and unnecessary website permission requests and downloads denied. Credential-like URL query or fragment parameters are redacted from captured evidence. Recordings and recovery drafts remain local until the person recording exports or deletes them; only an exported zip is intended for sharing.
+The experimental desktop preview loads remote pages in an Electron browser surface with Node integration disabled, context isolation and sandboxing enabled, and unnecessary website permission requests and downloads denied. Credential-like URL query or fragment parameters are redacted from captured evidence. Recordings and recovery drafts remain local until the person recording exports or deletes them; only an exported zip is intended for sharing.
 
 ## Bundle Notes
 

--- a/desktop/assets/index.html
+++ b/desktop/assets/index.html
@@ -7,7 +7,7 @@
       content="default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self' data:; connect-src 'none'; object-src 'none'; base-uri 'none'; form-action 'none'"
     />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Riffrec</title>
+    <title>Riffrec Desktop — Experimental Preview</title>
     <link rel="stylesheet" href="./styles.css" />
   </head>
   <body>
@@ -17,6 +17,7 @@
           <span class="brand-mark"></span>
           <span class="brand-name">riffrec</span>
         </div>
+        <span class="experimental-badge">Experimental preview</span>
         <nav class="browser-actions" aria-label="Browser controls">
           <button id="back" class="icon-button" type="button" aria-label="Back" disabled>&larr;</button>
           <button id="forward" class="icon-button" type="button" aria-label="Forward" disabled>&rarr;</button>
@@ -42,12 +43,16 @@
 
       <main class="workspace">
         <section id="empty-state" class="empty-state" aria-label="Get started">
-          <p class="overline">Standalone feedback browser</p>
+          <p class="overline">Highly experimental desktop preview</p>
           <h1>Record what happened,<br />while it is happening.</h1>
           <p class="empty-copy">
             Open any website here. Riffrec captures the page, your narration, clicks,
             navigations, failed requests, and console errors into one local feedback session.
           </p>
+          <div class="experimental-notice" role="note" aria-label="Experimental preview warning">
+            <strong>This app is a rough experiment.</strong>
+            <span>It may break or change without notice. The React package is the recommended way to use Riffrec.</span>
+          </div>
           <div class="workflow-steps" aria-label="Recording workflow">
             <div><span>01</span><strong>Open a site</strong><small>Sign in here if needed.</small></div>
             <div><span>02</span><strong>Reproduce it</strong><small>Speak and mark moments.</small></div>

--- a/desktop/assets/styles.css
+++ b/desktop/assets/styles.css
@@ -108,6 +108,18 @@ textarea:focus-visible {
   letter-spacing: -0.04em;
 }
 
+.experimental-badge {
+  flex: 0 0 auto;
+  padding: 5px 8px;
+  border: 1px solid rgba(181, 65, 46, 0.28);
+  border-radius: 999px;
+  background: var(--red-soft);
+  color: var(--red-dark);
+  font-size: 11px;
+  font-weight: 650;
+  white-space: nowrap;
+}
+
 .browser-actions {
   display: flex;
   gap: 5px;
@@ -251,10 +263,28 @@ textarea:focus-visible {
 
 .empty-copy {
   max-width: 480px;
-  margin: 26px 0 38px;
+  margin: 26px 0 20px;
   color: var(--muted);
   line-height: 1.65;
   font-size: 16px;
+}
+
+.experimental-notice {
+  max-width: 560px;
+  margin: 0 0 30px;
+  padding: 13px 15px;
+  border-left: 3px solid var(--red);
+  background: var(--red-soft);
+  color: var(--muted);
+  font-size: 13px;
+  line-height: 1.5;
+}
+
+.experimental-notice strong {
+  display: block;
+  margin-bottom: 2px;
+  color: var(--red-dark);
+  font-weight: 650;
 }
 
 .workflow-steps {

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -512,21 +512,21 @@
       }
     },
     "node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
+        "@emnapi/wasi-threads": "1.2.2",
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -535,9 +535,9 @@
       }
     },
     "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
-      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -1068,14 +1068,14 @@
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
-      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
+      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@tybys/wasm-util": "^0.10.1"
+        "@tybys/wasm-util": "^0.10.3"
       },
       "funding": {
         "type": "github",
@@ -1087,9 +1087,9 @@
       }
     },
     "node_modules/@oxc-project/types": {
-      "version": "0.132.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.132.0.tgz",
-      "integrity": "sha512-FESMOxil5Se014ui/Eq8fT5uHJo6nIRwH0PfJrZJXs6Gek3ZVFOrpUv3YIZT20m+extU98Hg1Ym72U58rlsxUQ==",
+      "version": "0.137.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.137.0.tgz",
+      "integrity": "sha512-WT+Gb24i8hmvo85AIv2oEYouEXkRlKAlT9WaCa3TfLgNCN+GhrJOGZuIlMouAh38Qe4QOx26eUOVsq70qXrywA==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -1097,9 +1097,9 @@
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.2.tgz",
-      "integrity": "sha512-ZS4D1JPGn/MYQN/SYDWftIE/nVsM8j/AFOYEzAoOE2O3NktQOZru+/vYXGbR/qtdLdIfGCP0lcoJiYVzsEz+iQ==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.3.tgz",
+      "integrity": "sha512-DT6Z3PhvioeHMvxo+xHc3KtqggrI7CCTXCmC2h/5zUlp5jVitv7XEy+9q5/7v8IolhlioawpMo8Kg0EEBy7J0g==",
       "cpu": [
         "arm64"
       ],
@@ -1114,9 +1114,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.2.tgz",
-      "integrity": "sha512-vdFA9+C/rekyGce7WqHs/xoT0ioZEWaOFyZLIV1mEeNFaFDUQrPIo8Vs2GvJ6eetb3rzDUtUBgzto3ExpXJB3w==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.3.tgz",
+      "integrity": "sha512-0NwgwsjM7LrsuVnXMK3koTpagBNOhloc/BNjKqZjv4V5zI5r13qx69uVhRx+o5Z0yy4Hzq+lpy7TAgUG/ocvrw==",
       "cpu": [
         "arm64"
       ],
@@ -1131,9 +1131,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.2.tgz",
-      "integrity": "sha512-BewSOwTHazv77DTYiAZXSqqKZ4KP/KonFisDMVU7PImxoWfB2aepnPhd2E4SWz3zDzYgDNbs6jBmTdgNnF02GA==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.3.tgz",
+      "integrity": "sha512-YtiBp4disu6V560loT6PjMdiRaWmVvDNrUunAalbiFx2ggeJwxdAsgZMcoGP17uyAsTwAj5V1niksxlHnVQ1Sw==",
       "cpu": [
         "x64"
       ],
@@ -1148,9 +1148,9 @@
       }
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.2.tgz",
-      "integrity": "sha512-m41o7M0YWtUdqk61Tb+jnKb2rN++iRdIASlExkUoKfIAH30DOHCB8fVLzSUpbWHHU8esmEioY62PxzexE8MBuA==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.3.tgz",
+      "integrity": "sha512-yD3EkEdXk2LypPxnf/kSZHirarsI8gcPzc62SukhR9VJTyvV+F9Q/GxWNuCojc7sXyuVC4DxRGhdDK4X8VSsbw==",
       "cpu": [
         "x64"
       ],
@@ -1165,9 +1165,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.2.tgz",
-      "integrity": "sha512-jcojB9H7W/jS29pMKWAK1N+fU99vXodHDTatS3b3y/XSOCiHo0kkA74pL3jJmkoQtYpOCxDvaKs1fo2Ij/1X5w==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.3.tgz",
+      "integrity": "sha512-c+8vieQbsD7HNAHKIA34w0GJ9FedFFuJGD+7E6vz7Q3uqAIugL5p45fhlsj4UaAsHpcmlqugBWMhA0/j7o0sIg==",
       "cpu": [
         "arm"
       ],
@@ -1182,9 +1182,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.2.tgz",
-      "integrity": "sha512-1jn6qDU5iiOgFgygDzKUuKP0maTi0/f1+sBLgvij/76C77Nm3ts6ufz9Bjg5q5dduxiUIxtq86JIoBvo1xQ4Ig==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.3.tgz",
+      "integrity": "sha512-50jD0uUwLvur7Zz9LHz17kaAdTPjn5wN93hEgjvmYFRZwiR7ZJYovTd5ipyWJDAnXKvZ+wgc+/Ika6dwSF5OcA==",
       "cpu": [
         "arm64"
       ],
@@ -1202,9 +1202,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.2.tgz",
-      "integrity": "sha512-QVLO/czFMdoMFSqlX3bcswcJNm/23r+qoa/jgtmFc/qEp6/jXmIkDjF/XIo8dPfGaiwy1xfQn8o77L79GeXFgw==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.3.tgz",
+      "integrity": "sha512-BO9+oPL8K9poZJBfYPsXNtYjPE5uM3qeehT3aFcW4LITOl+iSqhp0abzjR2nWBUNjIZeKXjAEWBZ64WjNoHd6w==",
       "cpu": [
         "arm64"
       ],
@@ -1222,9 +1222,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.2.tgz",
-      "integrity": "sha512-hgO5Abm0w5UL6FEa2iFnZqo2KlK7TQ5QhV5x09hujBf7t5KzHQ1VmfPuTpqRy/rNlSxua3eWH374xxiVrP+lcA==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.3.tgz",
+      "integrity": "sha512-f3VpLB1vQ0Eo6ecr/6cekLnvYMFF4YBFoVGkfkvPLq1bAkbAwHYQPZKoAmG6OJyTcxxoC+AvezGx/S1obNC0Mw==",
       "cpu": [
         "ppc64"
       ],
@@ -1242,9 +1242,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.2.tgz",
-      "integrity": "sha512-fy8rXxuYEu602abC8MUNaPjYLIFzReOaEIEMKMUa0rFEUxNpVXhs15KSSQ4qlqSaM7B6rcj9rDZgADh/IGDzLQ==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.3.tgz",
+      "integrity": "sha512-AmurZ26Pqx/RI9N1gzEOCklkKXl927yjfXWUUS0O7Puh8ARM/Ob8qfrD3qnWksScdw6cSrW5PSHE9DyLu7+PtA==",
       "cpu": [
         "s390x"
       ],
@@ -1262,9 +1262,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.2.tgz",
-      "integrity": "sha512-0+bOkiQ779+r1WpoHOWHqncvyySci0vKph+myNDYb+im6meJAzHQXay6oEgnkHuUGouM1LKTZwqKpBow6Kj7CQ==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.3.tgz",
+      "integrity": "sha512-JJpqs8bRGITDOdbkNKnlojzBabbOHrqjSvDr0IVsZObE1lBcPjxItUEY9eWIDbxaJ3cGrXPWGfGkIxFijg/URg==",
       "cpu": [
         "x64"
       ],
@@ -1282,9 +1282,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.2.tgz",
-      "integrity": "sha512-mjSkrzZK5Qsl0a9d1JgILOiuZOSDTVdKENcSXBoqbzSrspLR/4/IRVDo5wd2GgZjNss/viBFJdeq+j7qH2nypw==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.3.tgz",
+      "integrity": "sha512-rSJcdjPxzA/by/6/rYs+v+bXU7UjvnbUWz8MJb6kh6+knqB1dCrtHg0uu7C/4haqJvqdkYHQ5IGn+tCH9GLW/g==",
       "cpu": [
         "x64"
       ],
@@ -1302,9 +1302,9 @@
       }
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.2.tgz",
-      "integrity": "sha512-1v5vHasdfQAZoEHakBV72LIFAC9JjnymsiKxp+GEr/ma3+NJCPSaYK+qavInOovJkgwFrs7GccX2d6IgDA3Z5w==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.3.tgz",
+      "integrity": "sha512-hQ3/PYkDJICgevvyNcVrihVeqq7k1Pp3VZ9lY+dauAYUJKO+auqApvANhvR1An9BhmqYKvW2Mu1F9u4DXSMLxQ==",
       "cpu": [
         "arm64"
       ],
@@ -1319,9 +1319,9 @@
       }
     },
     "node_modules/@rolldown/binding-wasm32-wasi": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.2.tgz",
-      "integrity": "sha512-mb1VobWn6NheziTk5/WEaR6AKVbrwT5sOi6C7zk3gy/pD1qtJfU1j4PgTo2NJnOtbL9Dl3Aeei8w9jJ7qC2jZQ==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.3.tgz",
+      "integrity": "sha512-Elcv/BtML9lXrV6JuKITc/grN2kYV9gjsQpW8Jfw4ioK0TOkjBjye0nnyqQNy9STNaI20lXNaQBRrD5gSgR0Yg==",
       "cpu": [
         "wasm32"
       ],
@@ -1329,18 +1329,18 @@
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/core": "1.10.0",
-        "@emnapi/runtime": "1.10.0",
-        "@napi-rs/wasm-runtime": "^1.1.4"
+        "@emnapi/core": "1.11.1",
+        "@emnapi/runtime": "1.11.1",
+        "@napi-rs/wasm-runtime": "^1.1.6"
       },
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.2.tgz",
-      "integrity": "sha512-SqKonF56vA/L2yHwHYcEp2P34URpOZ7d1fS635cTkpDnUtEGdUbhI6NzsPdqeSWvAAeGDrxjWjNmibDIdFf9/A==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.3.tgz",
+      "integrity": "sha512-2DrEfhluH9yhiaFApmsjsjwrSYbNcY1oFTzYSP1a535jDbV98zCFanA/96TBUd0iDFcxGmw9QRExwGCXz3U+/g==",
       "cpu": [
         "arm64"
       ],
@@ -1355,9 +1355,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.2.tgz",
-      "integrity": "sha512-v7qRI7gXLRINcOGXt+7YmAZ6iFuyZVMIoXAxhd8oP+DR9dLfL9GfNIx7PLMxmhZdvq8waUJBQiWN9EKNy+TRBQ==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.3.tgz",
+      "integrity": "sha512-OL4OMk7UPXOeVGGd3qo5zJyPIljf4AFgk5QAkPPS+OoLuOOozhuaQGC18MxVTnw/06q93gShAJzlwnSCY9YtqA==",
       "cpu": [
         "x64"
       ],
@@ -1775,9 +1775,9 @@
       "license": "MIT"
     },
     "node_modules/@tybys/wasm-util": {
-      "version": "0.10.2",
-      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
-      "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -3340,13 +3340,13 @@
       }
     },
     "node_modules/rolldown": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.2.tgz",
-      "integrity": "sha512-oZx5zVDtVB44AW3eaifgDml1gWRDZGvjcfdxonE4swNPG98PrrXjaO/KrnUjzlMnztCCRVlUueA1kCXhARGk6g==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.3.tgz",
+      "integrity": "sha512-1F1eEtUBtFvcGm1HQ9TiUIUHPQG7mSAODrhIzjxoUEFuo8OcbrGLiVLkevNgj84TE4lnHvnumwFjhJO5Eu135g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/types": "=0.132.0",
+        "@oxc-project/types": "=0.137.0",
         "@rolldown/pluginutils": "^1.0.0"
       },
       "bin": {
@@ -3356,21 +3356,21 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rolldown/binding-android-arm64": "1.0.2",
-        "@rolldown/binding-darwin-arm64": "1.0.2",
-        "@rolldown/binding-darwin-x64": "1.0.2",
-        "@rolldown/binding-freebsd-x64": "1.0.2",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.0.2",
-        "@rolldown/binding-linux-arm64-gnu": "1.0.2",
-        "@rolldown/binding-linux-arm64-musl": "1.0.2",
-        "@rolldown/binding-linux-ppc64-gnu": "1.0.2",
-        "@rolldown/binding-linux-s390x-gnu": "1.0.2",
-        "@rolldown/binding-linux-x64-gnu": "1.0.2",
-        "@rolldown/binding-linux-x64-musl": "1.0.2",
-        "@rolldown/binding-openharmony-arm64": "1.0.2",
-        "@rolldown/binding-wasm32-wasi": "1.0.2",
-        "@rolldown/binding-win32-arm64-msvc": "1.0.2",
-        "@rolldown/binding-win32-x64-msvc": "1.0.2"
+        "@rolldown/binding-android-arm64": "1.1.3",
+        "@rolldown/binding-darwin-arm64": "1.1.3",
+        "@rolldown/binding-darwin-x64": "1.1.3",
+        "@rolldown/binding-freebsd-x64": "1.1.3",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.1.3",
+        "@rolldown/binding-linux-arm64-gnu": "1.1.3",
+        "@rolldown/binding-linux-arm64-musl": "1.1.3",
+        "@rolldown/binding-linux-ppc64-gnu": "1.1.3",
+        "@rolldown/binding-linux-s390x-gnu": "1.1.3",
+        "@rolldown/binding-linux-x64-gnu": "1.1.3",
+        "@rolldown/binding-linux-x64-musl": "1.1.3",
+        "@rolldown/binding-openharmony-arm64": "1.1.3",
+        "@rolldown/binding-wasm32-wasi": "1.1.3",
+        "@rolldown/binding-win32-arm64-msvc": "1.1.3",
+        "@rolldown/binding-win32-x64-msvc": "1.1.3"
       }
     },
     "node_modules/rollup": {
@@ -3589,9 +3589,9 @@
       "license": "MIT"
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.16",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
-      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3802,9 +3802,9 @@
       "license": "MIT"
     },
     "node_modules/undici": {
-      "version": "7.26.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.26.0.tgz",
-      "integrity": "sha512-3O9Tf67pGhgOv9jM35AbhkXAKi13f3oy3aE4CSgr+TckGeY+/iu97ZXN+J7DpHPzLbVApFd1IFhcnBjREYXYcg==",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3819,17 +3819,17 @@
       "license": "MIT"
     },
     "node_modules/vite": {
-      "version": "8.0.14",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.14.tgz",
-      "integrity": "sha512-s4BJJ+5y1pYL6Otw51FHhVJQhPnuRinKig64g/1+EUNaJsd3gCKdD31IPFvswUgW9/60QT9oFHbZHbQK5imcxw==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.0.tgz",
+      "integrity": "sha512-BuJcQK/56NQTWDGn4ABea3q4SSBdNPWwNZKTkkUpcMPnLoquSYH8llRtSUIgoL1KSCpHt5eghLShn50mH36y7Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
         "postcss": "^8.5.15",
-        "rolldown": "1.0.2",
-        "tinyglobby": "^0.2.16"
+        "rolldown": "~1.1.2",
+        "tinyglobby": "^0.2.17"
       },
       "bin": {
         "vite": "bin/vite.js"
@@ -3845,7 +3845,7 @@
       },
       "peerDependencies": {
         "@types/node": "^20.19.0 || >=22.12.0",
-        "@vitejs/devtools": "^0.1.18",
+        "@vitejs/devtools": "^0.3.0",
         "esbuild": "^0.27.0 || ^0.28.0",
         "jiti": ">=1.21.0",
         "less": "^4.0.0",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "riffrec-desktop",
   "version": "0.1.0",
-  "description": "Standalone Riffrec feedback browser for macOS.",
+  "description": "Highly experimental standalone Riffrec feedback browser for macOS.",
   "private": true,
   "main": "dist/process/main.js",
   "scripts": {

--- a/desktop/src/main.ts
+++ b/desktop/src/main.ts
@@ -267,7 +267,7 @@ function createWindow(): void {
     height: 920,
     minWidth: 1020,
     minHeight: 700,
-    title: "Riffrec",
+    title: "Riffrec Desktop — Experimental Preview",
     titleBarStyle: "hiddenInset",
     backgroundColor: "#f3efe7",
     webPreferences: {

--- a/desktop/tests/experimental-positioning.test.ts
+++ b/desktop/tests/experimental-positioning.test.ts
@@ -1,0 +1,20 @@
+import { readFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const readProjectFile = (relativePath: string): Promise<string> =>
+  readFile(fileURLToPath(new URL(relativePath, import.meta.url)), "utf8");
+
+describe("experimental desktop positioning", () => {
+  it("labels the app as experimental and recommends the React package", async () => {
+    const html = await readProjectFile("../assets/index.html");
+    const manifest = JSON.parse(await readProjectFile("../package.json")) as {
+      description: string;
+    };
+
+    expect(html).toContain("Experimental preview");
+    expect(html).toContain("This app is a rough experiment.");
+    expect(html).toContain("The React package is the recommended way to use Riffrec.");
+    expect(manifest.description).toContain("Highly experimental");
+  });
+});

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -172,9 +172,11 @@ _None - ready for planning._
 - [Affects R12][Technical] File System Access API directory picker UX - one-time prompt with IndexedDB persistence vs per-session prompt
 - [Affects R1][Technical] Audio mixing strategy for R1 (getDisplayMedia) and R2 (getUserMedia) - two separate files (recording.webm + voice.webm) vs AudioContext mixing into one track
 
-## Future / Out of Scope for v1
+## Experimental / Outside the Primary Path
 
-- **Swift companion app**: Optional native macOS menu bar app for recording non-browser apps; would write `recording.webm` to the same session directory format so agent workflow is identical; planned post-v1
+- **React remains the product path**: The npm package is the recommended and supported integration surface.
+- **Desktop is an experiment**: The Electron desktop browser may be used for rough trials on unintegrated websites, but it is not a replacement for the React package and may change or disappear without notice.
+- **No native companion is planned**: A separate Swift menu bar recorder is outside the current product direction.
 
 ## Next Steps
 -> Begin implementation plan with `/ce-plan`


### PR DESCRIPTION
## Summary

Keep Riffrec Desktop as the experiment established in #8 and hardened in #9, while making the React package unmistakably the product path.

PR #13 removed the app and PR #14 restored it. This follow-up resolves the underlying ambiguity instead of repeating either extreme:

- README now leads with the recommended React integration and moves Desktop behind a strong experimental caution.
- The desktop app shows a persistent **Experimental preview** badge, a launch-state warning, and a window title that points users back to the React package.
- Requirements, changelog copy, future release automation, and the live Preview 3 release page all use the same hierarchy.
- The desktop build lockfile was refreshed so its high-severity audit gate remains usable.

The existing Preview 3 release title and notes were also updated immediately to warn direct-download users that the app may break or disappear and is not the recommended path.

## Why

The earlier desktop PRs show that this is not throwaway code: it has a deliberate security boundary, compatible session output, packaging checks, and a repaired DMG path. Keeping it preserves useful experimentation on unintegrated websites. Presenting it alongside React as an equal option, however, overstates its maturity and obscures Riffrec's differentiator: the React integration's deeper in-app context.

## Validation

- Root: 35 test files / 116 tests passed; typecheck and build passed.
- Desktop: 9 test files / 33 tests passed; typecheck and build passed.
- Desktop packaging produced the macOS app, zip, and DMG.
- Desktop audit passes at high severity; one low Windows-only development-server advisory remains.
- Added a regression test that requires the app to label itself experimental and recommend React.
- `git diff --check` passed.

Visual browser capture was unavailable in this session, so UI verification is backed by the built HTML, packaging output, and the positioning regression test.

## Operational note

No runtime rollout is involved. After merge, future desktop preview releases will inherit the experimental warning; the already-published Preview 3 release page has been updated separately.

---

Related: #8, #9, #13, #14